### PR TITLE
Fix color for bash

### DIFF
--- a/nofetch.sh
+++ b/nofetch.sh
@@ -11,12 +11,12 @@ normal=$(tput sgr0)
 
 
 # Arbitrary colors to be used for text color. Default is used if not put as a command-line argument.
-red='\033[38;5;1m'
-green='\033[38;5;2m'
-yellow='\033[38;5;3m'
-blue='\033[38;5;4m'
-magenta='\033[38;5;5m'
-cyan='\033[38;5;6m'
+red="$(printf '\033[38;5;1m')"
+green="$(printf '\033[38;5;2m')"
+yellow="$(printf '\033[38;5;3m')"
+blue="$(printf '\033[38;5;4m')"
+magenta="$(printf '\033[38;5;5m')"
+cyan="$(printf '\033[38;5;6m')"
 
 # Sets the color to be used in the output via a command-line argument
 set_color () {


### PR DESCRIPTION
This should fix issue #2.

Calling the script `nofetch.sh` will use '/bin/sh' to interpret it.
On Linux, /bin/sh should link to any POSIX compliant shell (Ignoring that they sometimes do not comply in subtle ways). It could be `dash`, `bash`, `ksh`, ...
In Arch, /bin/sh is linked to bash, which does not interpret backslash character sequences like `\033` in `echo`.

The issue can be reproduced by calling the shell by name directly to read the script, for example:
```sh
bash /path/to/nofetch.sh green
```

The solution from this pull request is to use `printf` to interpret the `\033` sequence when assigning color variables so that instead of containing a backslash, the character 0, the character 3 and the character 3, color variables contain the "escape" character directly, preventing `echo` from interpreting it differently.

To conclude, using `echo` with an argument containing a backslash is not portable. For `echo` to be portable, we have to make sure that there is no backslash (and also that its first argument is not `-n`, because of bash). If there is no way to be sure in advance about it, like when outputing a user input, something like `printf '%s\n' "$user_input"` could be used.